### PR TITLE
Feat/redeem limits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Show Forge version
         run: |


### PR DESCRIPTION
- Added a daily limit of 0.01 BTC for account redims
- Added a global limit of 1 BTC per day for redims
- Both limits are parameterized
- It is possible to enable or disable this limit